### PR TITLE
fix for dotfiles/bin/wifi

### DIFF
--- a/bin/wifi
+++ b/bin/wifi
@@ -98,6 +98,7 @@ rate="${info[2]}"   # bandwidth of wifi wave
 ssid="${info[3]}"   # wifi ssid name
 
 # Determine the signal from rssi of wifi
+signal=""
 for ((j = 0; j < "${#signals[@]}"; j++))
 do
     # reference of strength (rssi)


### PR DESCRIPTION
使用環境：OS X , tmux , iTerm2

ステータスバーにwi-fiを表示させると、signalに空白文字列が入ってしまうエラーの修正(signalの初期化)